### PR TITLE
fix typo

### DIFF
--- a/ZalithLauncher/src/main/jni/egl_bridge.c
+++ b/ZalithLauncher/src/main/jni/egl_bridge.c
@@ -143,7 +143,7 @@ int pojavInitOpenGL() {
         set_osm_bridge_tbl();
     }
 
-    if (!strcmp(renderer, "gallium_freedteno"))
+    if (!strcmp(renderer, "gallium_freedreno"))
     {
         pojav_environ->config_renderer = RENDERER_VK_ZINK;
         setenv("MESA_LOADER_DRIVER_OVERRIDE", "kgsl", 1);


### PR DESCRIPTION
when freedreno is selected as renderer because of typo set_osm_bridge_tbl is not called and bl_init is NULL. When it calls Segmentation Fault occurs and game crashes